### PR TITLE
Add Xcode workflow for building simulator IPA and Google Cloud Run support

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,9 @@
 Local_IP = 192.168.1.189
 SECRET_KEY=readPandaSecretKeyForReactNative@17356
 API_VERSION= /api/v1
+# When deploying the Go backend to Google Cloud Run, set this to the service
+# base URL (no trailing slash, no API version path), e.g.:
+#   BACKEND_URL=https://readpanda-backend-<YOUR-SERVICE-ID>-uc.a.run.app
+# API_VERSION is always appended automatically by getBackendUrl().
+# Leave empty to use the Local_IP + port 3000 setup for local development.
+BACKEND_URL=

--- a/.github/workflows/xcode-build-analyze.yml
+++ b/.github/workflows/xcode-build-analyze.yml
@@ -31,10 +31,12 @@ jobs:
           LOCAL_IP: ${{ secrets.LOCAL_IP || '127.0.0.1' }}
           SECRET_KEY: ${{ secrets.SECRET_KEY || 'ci-placeholder-secret' }}
           API_VERSION: ${{ secrets.API_VERSION || '/api/v1' }}
+          BACKEND_URL: ${{ secrets.BACKEND_URL || '' }}
         run: |
           echo "Local_IP=${LOCAL_IP}" > .env
           echo "SECRET_KEY=${SECRET_KEY}" >> .env
           echo "API_VERSION=${API_VERSION}" >> .env
+          echo "BACKEND_URL=${BACKEND_URL}" >> .env
 
       - name: Cache CocoaPods
         uses: actions/cache@v4

--- a/.github/workflows/xcode-build-analyze.yml
+++ b/.github/workflows/xcode-build-analyze.yml
@@ -55,11 +55,27 @@ jobs:
       - name: Build and Analyze
         run: |
           set -o pipefail
-          xcodebuild clean analyze \
+          xcodebuild clean analyze build \
             -workspace ios/ReadPanda.xcworkspace \
             -scheme ReadPanda \
             -sdk iphonesimulator \
+            -configuration Debug \
+            -derivedDataPath build/DerivedData \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
             CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \
             | xcpretty
+
+      - name: Package Simulator IPA
+        run: |
+          APP_PATH="build/DerivedData/Build/Products/Debug-iphonesimulator/ReadPanda.app"
+          mkdir -p build/Payload
+          cp -r "$APP_PATH" build/Payload/
+          cd build && zip -r ReadPanda-Simulator.ipa Payload/
+
+      - name: Upload Simulator IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReadPanda-Simulator-IPA
+          path: build/ReadPanda-Simulator.ipa
+          retention-days: 7

--- a/.github/workflows/xcode-build-analyze.yml
+++ b/.github/workflows/xcode-build-analyze.yml
@@ -1,0 +1,65 @@
+name: Xcode - Build and Analyze
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-and-analyze:
+    name: Build and Analyze
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      - name: Install JavaScript dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Create .env file
+        env:
+          LOCAL_IP: ${{ secrets.LOCAL_IP || '127.0.0.1' }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY || 'ci-placeholder-secret' }}
+          API_VERSION: ${{ secrets.API_VERSION || '/api/v1' }}
+        run: |
+          echo "Local_IP=${LOCAL_IP}" > .env
+          echo "SECRET_KEY=${SECRET_KEY}" >> .env
+          echo "API_VERSION=${API_VERSION}" >> .env
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install CocoaPods dependencies
+        run: |
+          cd ios
+          pod install
+
+      - name: Install xcpretty
+        run: gem install xcpretty
+
+      - name: Build and Analyze
+        run: |
+          set -o pipefail
+          xcodebuild clean analyze \
+            -workspace ios/ReadPanda.xcworkspace \
+            -scheme ReadPanda \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            CODE_SIGNING_ALLOWED=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            | xcpretty

--- a/.github/workflows/xcode-build-analyze.yml
+++ b/.github/workflows/xcode-build-analyze.yml
@@ -2,9 +2,9 @@ name: Xcode - Build and Analyze
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
-    branches: ["main"]
+    branches: ["master"]
 
 jobs:
   build-and-analyze:
@@ -61,23 +61,22 @@ jobs:
             -workspace ios/ReadPanda.xcworkspace \
             -scheme ReadPanda \
             -sdk iphonesimulator \
-            -configuration Debug \
+            -configuration Release \
             -derivedDataPath build/DerivedData \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
             CODE_SIGNING_ALLOWED=NO \
             COMPILER_INDEX_STORE_ENABLE=NO \
             | xcpretty
 
-      - name: Package Simulator IPA
+      - name: Package Simulator App
         run: |
-          APP_PATH="build/DerivedData/Build/Products/Debug-iphonesimulator/ReadPanda.app"
-          mkdir -p build/Payload
-          cp -r "$APP_PATH" build/Payload/
-          cd build && zip -r ReadPanda-Simulator.ipa Payload/
+          APP_PATH="build/DerivedData/Build/Products/Release-iphonesimulator/ReadPanda.app"
+          cd $(dirname "$APP_PATH")
+          zip -r ../../../../../ReadPanda-Simulator.app.zip ReadPanda.app
 
-      - name: Upload Simulator IPA
+      - name: Upload Simulator App
         uses: actions/upload-artifact@v4
         with:
-          name: ReadPanda-Simulator-IPA
-          path: build/ReadPanda-Simulator.ipa
+          name: ReadPanda-Simulator-App
+          path: ReadPanda-Simulator.app.zip
           retention-days: 7

--- a/.github/workflows/xcode-build-analyze.yml
+++ b/.github/workflows/xcode-build-analyze.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
 
       - name: Install JavaScript dependencies

--- a/ios/.xcode.env.local
+++ b/ios/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY=/Users/nvaditya/.nvm/versions/node/v24.14.0/bin/node

--- a/src/utils/Helper.js
+++ b/src/utils/Helper.js
@@ -1,10 +1,17 @@
-import { Local_IP, API_VERSION } from '@env';
+import { Local_IP, API_VERSION, BACKEND_URL } from '@env';
 import messaging from '@react-native-firebase/messaging';
 import log from '../utils/logger';
 import { saveNotification, NotificationType } from './notification';
 
 const getBackendUrl = (path = '') => {
   try {
+    // When BACKEND_URL is set (e.g. a Google Cloud Run service base URL) use
+    // it in place of the Local_IP + port combination.  API_VERSION is always
+    // appended so both code paths produce the same URL shape.
+    // Example: BACKEND_URL=https://readpanda-backend-<SERVICE-ID>-uc.a.run.app
+    if (BACKEND_URL) {
+      return `${BACKEND_URL}${API_VERSION}${path}`;
+    }
     const ip = Local_IP || 'localhost';
     const port = 3000;
     return `http://${ip}:${port}${API_VERSION}${path}`;


### PR DESCRIPTION
This pull request introduces a new workflow for building and analyzing the iOS app with Xcode in CI, and improves backend URL configuration for both local development and cloud deployment. The most important changes are grouped below:

**Continuous Integration Improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/xcode-build-analyze.yml`) to automatically build, analyze, and package the iOS app for the simulator on pushes and pull requests to the `main` branch. This workflow also manages dependencies, caches CocoaPods, and uploads the resulting IPA artifact.

**Backend URL Configuration Enhancements:**

* Updated `.env` to support a `BACKEND_URL` variable, allowing deployment to Google Cloud Run or other remote environments by specifying a base URL instead of relying solely on `Local_IP` and local ports.
* Improved the `getBackendUrl` function in `src/utils/Helper.js` to use `BACKEND_URL` when set, ensuring seamless switching between local and cloud backend environments.